### PR TITLE
(Feature) Add AutoUpdate Functionality - V1.0.0.118

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,96 @@
 const electron = require('electron')
-// Module to control application life.
-const app = electron.app
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
+// Module to control application life + native browser window + autoUpdater
+const {app,BrowserWindow,autoUpdater} = electron
 
 const path = require('path')
 const url = require('url')
+const feedURL = 'https://github.com/Necrobot-Private/NecroBot/releases';
+
+// START UPDATE EVENT - Check for Updates on Launch
+autoUpdater.setFeedURL(feedURL);
+
+if (handleSquirrelEvent()) {
+  // squirrel event handled and app will exit in 1000ms, so don't do anything else
+  return;
+}
+
+autoUpdater.addListener("update-downloaded", function(event, releaseNotes, releaseName, releaseDate, updateURL) {
+		 dialog.showMessageBox({
+			type: 'info',
+			title: 'Update has been Completed',
+			buttons: ['Restart now', 'Later'],
+			message: 'Version '+ releaseName +' has been downloaded, Would you like to restart?'
+		  }, function (buttonIndex){
+			  if(buttonIndex == 0)
+			  {
+				  autoUpdater.quitAndInstall();
+			  }
+			}
+		  );
+});
+
+function handleSquirrelEvent() {
+  if (process.argv.length === 1) {
+    return false;
+  }
+
+  const ChildProcess = require('child_process');
+  const path = require('path');
+
+  const appFolder = path.resolve(process.execPath, '..');
+  const rootAtomFolder = path.resolve(appFolder, '..');
+  const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
+  const exeName = path.basename(process.execPath);
+
+  const spawn = function(command, args) {
+    let spawnedProcess, error;
+
+    try {
+      spawnedProcess = ChildProcess.spawn(command, args, {detached: true});
+    } catch (error) {}
+
+    return spawnedProcess;
+  };
+
+  const spawnUpdate = function(args) {
+    return spawn(updateDotExe, args);
+  };
+
+  const squirrelEvent = process.argv[1];
+  switch (squirrelEvent) {
+    case '--squirrel-install':
+    case '--squirrel-updated':
+      // Optionally do things such as:
+      // - Add your .exe to the PATH
+      // - Write to the registry for things like file associations and
+      //   explorer context menus
+
+      // Install desktop and start menu shortcuts
+      spawnUpdate(['--createShortcut', exeName]);
+
+      setTimeout(app.quit, 1000);
+      return true;
+
+    case '--squirrel-uninstall':
+      // Undo anything you did in the --squirrel-install and
+      // --squirrel-updated handlers
+
+      // Remove desktop and start menu shortcuts
+      spawnUpdate(['--removeShortcut', exeName]);
+
+      setTimeout(app.quit, 1000);
+      return true;
+
+    case '--squirrel-obsolete':
+      // This is called on the outgoing version of your app before
+      // we update to the new version - it's the opposite of
+      // --squirrel-updated
+
+      app.quit();
+      return true;
+  }
+};
+// END UPDATE EVENT
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NecroBot2-GUI",
-  "version": "1.0.0",
+  "version": "1.0.0.118",
   "description": "Necrobot2 GUI (PokeEase Fork)",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Pull Request Info

- Adds the Ability to AutoUpdate PokeEase, just like WinGui, and console already have the ability to do
- Sets the Proper Version to match Necrobot

## Changes

- Release Binaries, the files added to a release, must now contain All files in Dist/Win Folder after building.
Ex: Setup.exe, RELEASES File, all .nugpkg(For that Version)
- In package.json the version must be increased in order to count as an update to the App

## Compatibility

The autoUpdate as well as The install .exe only had support with windows, however more work can go into it to add support on Mac and Linux

## Affected Files

- Main.js (Main Update code)
- package.json (Version Management)