### PR TITLE
GUI: Correct Grammer

### DIFF
--- a/PokeEase-Necrobot-Private/index.html
+++ b/PokeEase-Necrobot-Private/index.html
@@ -355,7 +355,7 @@
                     <span class="current">0</span>/<span class="total">9</span>
                 </div>
             </div>
-            <div class="item" id="snipes" title="Snipable Pokemons">
+            <div class="item" id="snipes" title="Snipable Pokémon">
                 <div class="counter">
                     <span class="current">0</span>
                 </div>


### PR DESCRIPTION
As with the words deer and sheep, the singular and plural forms of the word "Pokémon" do not differ, nor does each individual species name; in short, it is grammatically correct to say both "one Pokémon" and "many Pokémon".
(**source: <a href="https://en.wikipedia.org/wiki/Portal:Pok%C3%A9mon">Wikipedia</a>**)